### PR TITLE
feat(queuev2): integrate InMemQueue with cache.Manager for host-level task-count tracking

### DIFF
--- a/service/history/queuev2/queue_mem.go
+++ b/service/history/queuev2/queue_mem.go
@@ -170,7 +170,8 @@ func (q *inMemQueueImpl) RTrimBySize() (persistence.HistoryTaskKey, bool) {
 		return persistence.MinimumHistoryTaskKey, false
 	}
 	trimmed := false
-	for len(q.tasks) > 0 && q.budgetMgr.UsedCount() > q.budgetMgr.CapacityCount() {
+	// Use q.Len() (not UsedCount) because reserve may fail for tasks inserted while at capacity.
+	for len(q.tasks) > 0 && int64(len(q.tasks)) > q.budgetMgr.CapacityCount() {
 		q.tasks[len(q.tasks)-1] = nil // release GC ref
 		q.tasks = q.tasks[:len(q.tasks)-1]
 		_ = q.budgetMgr.ReleaseCountWithCallback(q.cacheID, func() (int64, error) { return 1, nil })

--- a/service/history/queuev2/queue_mem.go
+++ b/service/history/queuev2/queue_mem.go
@@ -169,19 +169,17 @@ func (q *inMemQueueImpl) RTrimBySize() (persistence.HistoryTaskKey, bool) {
 	if len(q.tasks) == 0 {
 		return persistence.MinimumHistoryTaskKey, false
 	}
-	prevLen := len(q.tasks)
+	trimmed := false
 	for len(q.tasks) > 0 && q.budgetMgr.UsedCount() > q.budgetMgr.CapacityCount() {
 		q.tasks[len(q.tasks)-1] = nil // release GC ref
 		q.tasks = q.tasks[:len(q.tasks)-1]
-	}
-	freed := int64(prevLen - len(q.tasks))
-	if freed > 0 {
-		_ = q.budgetMgr.ReleaseCountWithCallback(q.cacheID, func() (int64, error) { return freed, nil })
+		_ = q.budgetMgr.ReleaseCountWithCallback(q.cacheID, func() (int64, error) { return 1, nil })
+		trimmed = true
 	}
 	if len(q.tasks) == 0 {
-		return persistence.MinimumHistoryTaskKey, freed > 0
+		return persistence.MinimumHistoryTaskKey, trimmed
 	}
-	return q.tasks[len(q.tasks)-1].GetTaskKey().Next(), freed > 0
+	return q.tasks[len(q.tasks)-1].GetTaskKey().Next(), trimmed
 }
 
 // Clear removes all tasks from the queue.

--- a/service/history/queuev2/queue_mem.go
+++ b/service/history/queuev2/queue_mem.go
@@ -25,6 +25,7 @@ package queuev2
 import (
 	"sort"
 
+	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/persistence"
 )
 
@@ -43,10 +44,10 @@ type InMemQueue interface {
 	GetTasks(inclusiveMinTaskKey, exclusiveMaxTaskKey persistence.HistoryTaskKey, predicate Predicate, pageSize int) (tasks []persistence.Task, nextTaskKey persistence.HistoryTaskKey)
 	// LTrim removes all tasks strictly before newInclusiveMinTaskKey.
 	LTrim(newInclusiveMinTaskKey persistence.HistoryTaskKey)
-	// RTrimBySize drops tasks from the tail until Len() <= maxSize.
+	// RTrimBySize drops tasks from the tail while the host total exceeds capacity.
 	// Returns the key just past the last kept task and true if any tasks were
 	// removed, or the zero key and false if the queue was already within bounds.
-	RTrimBySize(maxSize int) (persistence.HistoryTaskKey, bool)
+	RTrimBySize() (persistence.HistoryTaskKey, bool)
 	// Clear removes all tasks.
 	Clear()
 	// Len returns the number of tasks currently in the queue.
@@ -54,11 +55,13 @@ type InMemQueue interface {
 }
 
 type inMemQueueImpl struct {
-	tasks []persistence.Task
+	tasks     []persistence.Task
+	budgetMgr cache.Manager
+	cacheID   string
 }
 
-func newInMemQueue() *inMemQueueImpl {
-	return &inMemQueueImpl{}
+func newInMemQueueWithBudget(mgr cache.Manager, cacheID string) *inMemQueueImpl {
+	return &inMemQueueImpl{budgetMgr: mgr, cacheID: cacheID}
 }
 
 // putTask inserts a task into the queue maintaining sorted order by task key.
@@ -70,6 +73,7 @@ func (q *inMemQueueImpl) putTask(task persistence.Task) {
 	// Fast path: empty queue or key is strictly greater than the tail — append directly.
 	if n == 0 || q.tasks[n-1].GetTaskKey().Compare(key) < 0 {
 		q.tasks = append(q.tasks, task)
+		_ = q.budgetMgr.ReserveCountWithCallback(q.cacheID, 1, func() error { return nil })
 		return
 	}
 
@@ -82,6 +86,7 @@ func (q *inMemQueueImpl) putTask(task persistence.Task) {
 	q.tasks = append(q.tasks, nil)
 	copy(q.tasks[pos+1:], q.tasks[pos:])
 	q.tasks[pos] = task
+	_ = q.budgetMgr.ReserveCountWithCallback(q.cacheID, 1, func() error { return nil })
 }
 
 // PutTasks inserts multiple tasks into the queue.
@@ -150,41 +155,40 @@ func (q *inMemQueueImpl) LTrim(newInclusiveMinTaskKey persistence.HistoryTaskKey
 		return
 	}
 
+	freed := int64(pos)
 	remaining := make([]persistence.Task, len(q.tasks)-pos)
 	copy(remaining, q.tasks[pos:])
 	q.tasks = remaining
+	_ = q.budgetMgr.ReleaseCountWithCallback(q.cacheID, func() (int64, error) { return freed, nil })
 }
 
-// RTrimBySize truncates the queue to at most maxSize elements by dropping
-// the newest tasks from the right.
+// RTrimBySize trims tasks from the tail while the host total exceeds capacity,
+// releasing each removed task from the budget.
 // Returns the next key after the last task or MinimumHistoryTaskKey if the queue is empty, and
 // true if any tasks were removed, or false if the queue was already within bounds.
-func (q *inMemQueueImpl) RTrimBySize(maxSize int) (persistence.HistoryTaskKey, bool) {
+func (q *inMemQueueImpl) RTrimBySize() (persistence.HistoryTaskKey, bool) {
 	if len(q.tasks) == 0 {
 		return persistence.MinimumHistoryTaskKey, false
 	}
-
-	if maxSize <= 0 {
-		q.tasks = nil
-		return persistence.MinimumHistoryTaskKey, true
+	trimmed := false
+	for len(q.tasks) > 0 && q.budgetMgr.UsedCount() > q.budgetMgr.CapacityCount() {
+		q.tasks[len(q.tasks)-1] = nil // release GC ref
+		q.tasks = q.tasks[:len(q.tasks)-1]
+		_ = q.budgetMgr.ReleaseCountWithCallback(q.cacheID, func() (int64, error) { return 1, nil })
+		trimmed = true
 	}
-
-	trimmed := len(q.tasks) > maxSize
-	if trimmed {
-		// Nil out the tail elements so the backing array releases references to
-		// the removed Task interface values. Without this, interface values beyond
-		// maxSize remain rooted in the array until it is reallocated.
-		for i := maxSize; i < len(q.tasks); i++ {
-			q.tasks[i] = nil
-		}
-		q.tasks = q.tasks[:maxSize]
+	if len(q.tasks) == 0 {
+		return persistence.MinimumHistoryTaskKey, trimmed
 	}
-
 	return q.tasks[len(q.tasks)-1].GetTaskKey().Next(), trimmed
 }
 
 // Clear removes all tasks from the queue.
 func (q *inMemQueueImpl) Clear() {
+	n := int64(len(q.tasks))
+	if n > 0 {
+		_ = q.budgetMgr.ReleaseCountWithCallback(q.cacheID, func() (int64, error) { return n, nil })
+	}
 	q.tasks = nil
 }
 

--- a/service/history/queuev2/queue_mem.go
+++ b/service/history/queuev2/queue_mem.go
@@ -44,9 +44,9 @@ type InMemQueue interface {
 	GetTasks(inclusiveMinTaskKey, exclusiveMaxTaskKey persistence.HistoryTaskKey, predicate Predicate, pageSize int) (tasks []persistence.Task, nextTaskKey persistence.HistoryTaskKey)
 	// LTrim removes all tasks strictly before newInclusiveMinTaskKey.
 	LTrim(newInclusiveMinTaskKey persistence.HistoryTaskKey)
-	// RTrimBySize drops tasks from the tail while the host total exceeds capacity.
-	// Returns the key just past the last kept task and true if any tasks were
-	// removed, or the zero key and false if the queue was already within bounds.
+	// RTrimBySize trims the tail until the host-level budget capacity is satisfied.
+	// Returns the key after the last retained task (or MinimumHistoryTaskKey if empty)
+	// and true if any tasks were removed.
 	RTrimBySize() (persistence.HistoryTaskKey, bool)
 	// Clear removes all tasks.
 	Clear()
@@ -162,25 +162,26 @@ func (q *inMemQueueImpl) LTrim(newInclusiveMinTaskKey persistence.HistoryTaskKey
 	_ = q.budgetMgr.ReleaseCountWithCallback(q.cacheID, func() (int64, error) { return freed, nil })
 }
 
-// RTrimBySize trims tasks from the tail while the host total exceeds capacity,
-// releasing each removed task from the budget.
-// Returns the next key after the last task or MinimumHistoryTaskKey if the queue is empty, and
-// true if any tasks were removed, or false if the queue was already within bounds.
+// RTrimBySize trims the tail until the host-level budget capacity is satisfied.
+// Returns the key after the last retained task (or MinimumHistoryTaskKey if empty)
+// and true if any tasks were removed.
 func (q *inMemQueueImpl) RTrimBySize() (persistence.HistoryTaskKey, bool) {
 	if len(q.tasks) == 0 {
 		return persistence.MinimumHistoryTaskKey, false
 	}
-	trimmed := false
+	prevLen := len(q.tasks)
 	for len(q.tasks) > 0 && q.budgetMgr.UsedCount() > q.budgetMgr.CapacityCount() {
 		q.tasks[len(q.tasks)-1] = nil // release GC ref
 		q.tasks = q.tasks[:len(q.tasks)-1]
-		_ = q.budgetMgr.ReleaseCountWithCallback(q.cacheID, func() (int64, error) { return 1, nil })
-		trimmed = true
+	}
+	freed := int64(prevLen - len(q.tasks))
+	if freed > 0 {
+		_ = q.budgetMgr.ReleaseCountWithCallback(q.cacheID, func() (int64, error) { return freed, nil })
 	}
 	if len(q.tasks) == 0 {
-		return persistence.MinimumHistoryTaskKey, trimmed
+		return persistence.MinimumHistoryTaskKey, freed > 0
 	}
-	return q.tasks[len(q.tasks)-1].GetTaskKey().Next(), trimmed
+	return q.tasks[len(q.tasks)-1].GetTaskKey().Next(), freed > 0
 }
 
 // Clear removes all tasks from the queue.

--- a/service/history/queuev2/queue_mem_mock.go
+++ b/service/history/queuev2/queue_mem_mock.go
@@ -121,16 +121,16 @@ func (mr *MockInMemQueueMockRecorder) PutTasks(tasks any) *gomock.Call {
 }
 
 // RTrimBySize mocks base method.
-func (m *MockInMemQueue) RTrimBySize(maxSize int) (persistence.HistoryTaskKey, bool) {
+func (m *MockInMemQueue) RTrimBySize() (persistence.HistoryTaskKey, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RTrimBySize", maxSize)
+	ret := m.ctrl.Call(m, "RTrimBySize")
 	ret0, _ := ret[0].(persistence.HistoryTaskKey)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // RTrimBySize indicates an expected call of RTrimBySize.
-func (mr *MockInMemQueueMockRecorder) RTrimBySize(maxSize any) *gomock.Call {
+func (mr *MockInMemQueueMockRecorder) RTrimBySize() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RTrimBySize", reflect.TypeOf((*MockInMemQueue)(nil).RTrimBySize), maxSize)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RTrimBySize", reflect.TypeOf((*MockInMemQueue)(nil).RTrimBySize))
 }

--- a/service/history/queuev2/queue_mem_test.go
+++ b/service/history/queuev2/queue_mem_test.go
@@ -23,14 +23,53 @@
 package queuev2
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/persistence"
 )
+
+// newTestBudgetMgr creates a budget manager for tests.
+// maxCount < 0 means unlimited; >= 0 is an enforced cap.
+func newTestBudgetMgr(maxCount int64) cache.Manager {
+	return cache.NewBudgetManager(
+		"test",
+		dynamicproperties.GetIntPropertyFn(-1), // bytes: unlimited
+		dynamicproperties.GetIntPropertyFn(int(maxCount)),
+		cache.AdmissionOptimistic,
+		0, nil, nil, nil,
+	)
+}
+
+// mutableCountFn wraps an atomic so tests can change the capacity after construction.
+type mutableCountFn struct{ v atomic.Int64 }
+
+func newMutableCountFn(initial int64) *mutableCountFn {
+	f := &mutableCountFn{}
+	f.v.Store(initial)
+	return f
+}
+
+func (m *mutableCountFn) fn(_ ...dynamicproperties.FilterOption) int {
+	return int(m.v.Load())
+}
+
+// newTestBudgetMgrMutable creates a budget manager whose count capacity can be changed at runtime.
+func newTestBudgetMgrMutable(cap *mutableCountFn) cache.Manager {
+	return cache.NewBudgetManager(
+		"test",
+		dynamicproperties.GetIntPropertyFn(-1), // bytes: unlimited
+		cap.fn,
+		cache.AdmissionOptimistic,
+		0, nil, nil, nil,
+	)
+}
 
 // testTask is a minimal persistence.Task for testing InMemQueue.
 // It uses DeleteHistoryEventTask because it's a timer task that uses
@@ -126,7 +165,9 @@ func TestInMemQueue_putTask(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			q := newInMemQueue()
+			mgr := newTestBudgetMgr(-1)
+			defer mgr.Stop()
+			q := newInMemQueueWithBudget(mgr, "test")
 			for _, task := range tt.existing {
 				q.putTask(task)
 			}
@@ -178,7 +219,9 @@ func TestInMemQueue_PutTasks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			q := newInMemQueue()
+			mgr := newTestBudgetMgr(-1)
+			defer mgr.Stop()
+			q := newInMemQueueWithBudget(mgr, "test")
 			for _, task := range tt.existing {
 				q.putTask(task)
 			}
@@ -244,7 +287,9 @@ func TestInMemQueue_LookAHead(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			q := newInMemQueue()
+			mgr := newTestBudgetMgr(-1)
+			defer mgr.Stop()
+			q := newInMemQueueWithBudget(mgr, "test")
 			q.PutTasks(tt.tasks)
 
 			task := q.LookAHead(tt.minTaskKey)
@@ -352,7 +397,9 @@ func TestInMemQueue_GetTasks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			q := newInMemQueue()
+			mgr := newTestBudgetMgr(-1)
+			defer mgr.Stop()
+			q := newInMemQueueWithBudget(mgr, "test")
 			q.PutTasks(tt.tasks)
 
 			gotTasks, nextKey := q.GetTasks(tt.inclusiveMin, tt.exclusiveMax, tt.predicate, tt.pageSize)
@@ -427,7 +474,9 @@ func TestInMemQueue_LTrim(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			q := newInMemQueue()
+			mgr := newTestBudgetMgr(-1)
+			defer mgr.Stop()
+			q := newInMemQueueWithBudget(mgr, "test")
 			q.PutTasks(tt.tasks)
 
 			q.LTrim(tt.trimKey)
@@ -446,7 +495,7 @@ func TestInMemQueue_RTrimBySize(t *testing.T) {
 	tests := []struct {
 		name        string
 		tasks       []persistence.Task
-		maxSize     int
+		maxSize     int64
 		wantLen     int
 		wantTaskIDs []int64
 		wantKey     persistence.HistoryTaskKey
@@ -515,10 +564,17 @@ func TestInMemQueue_RTrimBySize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			q := newInMemQueue()
+			// Insert tasks with unlimited capacity so all fit.
+			cap := newMutableCountFn(-1)
+			mgr := newTestBudgetMgrMutable(cap)
+			defer mgr.Stop()
+			q := newInMemQueueWithBudget(mgr, "test")
 			q.PutTasks(tt.tasks)
 
-			gotKey, gotTrimmed := q.RTrimBySize(tt.maxSize)
+			// Now reduce capacity to maxSize to trigger trimming on next RTrimBySize call.
+			cap.v.Store(tt.maxSize)
+
+			gotKey, gotTrimmed := q.RTrimBySize()
 
 			assert.Equal(t, tt.wantLen, q.Len())
 			var gotIDs []int64
@@ -533,7 +589,9 @@ func TestInMemQueue_RTrimBySize(t *testing.T) {
 }
 
 func TestInMemQueue_Len(t *testing.T) {
-	q := newInMemQueue()
+	mgr := newTestBudgetMgr(-1)
+	defer mgr.Stop()
+	q := newInMemQueueWithBudget(mgr, "test")
 	assert.Equal(t, 0, q.Len())
 
 	q.putTask(newTestTask(time.Unix(10, 0), 1))
@@ -545,7 +603,9 @@ func TestInMemQueue_Len(t *testing.T) {
 }
 
 func TestInMemQueue_Clear(t *testing.T) {
-	q := newInMemQueue()
+	mgr := newTestBudgetMgr(-1)
+	defer mgr.Stop()
+	q := newInMemQueueWithBudget(mgr, "test")
 	q.PutTasks([]persistence.Task{
 		newTestTask(time.Unix(10, 0), 1),
 		newTestTask(time.Unix(20, 0), 2),
@@ -560,7 +620,11 @@ func TestInMemQueue_Clear(t *testing.T) {
 // backing array elements beyond maxSize so removed Task interface values are
 // eligible for GC and don't linger in the underlying array.
 func TestInMemQueue_RTrimBySize_NilsTail(t *testing.T) {
-	q := newInMemQueue()
+	// Insert 3 tasks with unlimited capacity, then shrink capacity to 1.
+	capFn := newMutableCountFn(-1)
+	mgr := newTestBudgetMgrMutable(capFn)
+	defer mgr.Stop()
+	q := newInMemQueueWithBudget(mgr, "test")
 	q.PutTasks([]persistence.Task{
 		newTestTask(time.Unix(1, 0), 1),
 		newTestTask(time.Unix(2, 0), 2),
@@ -569,7 +633,9 @@ func TestInMemQueue_RTrimBySize_NilsTail(t *testing.T) {
 	// Grow the backing array so we can inspect it after trimming.
 	cap0 := cap(q.tasks)
 
-	_, trimmed := q.RTrimBySize(1)
+	// Reduce capacity to 1 so RTrimBySize trims.
+	capFn.v.Store(1)
+	_, trimmed := q.RTrimBySize()
 	assert.True(t, trimmed)
 	assert.Equal(t, 1, q.Len())
 
@@ -583,7 +649,9 @@ func TestInMemQueue_RTrimBySize_NilsTail(t *testing.T) {
 }
 
 func TestInMemQueue_PutTasks_AppendFastPath(t *testing.T) {
-	q := newInMemQueue()
+	mgr := newTestBudgetMgr(-1)
+	defer mgr.Stop()
+	q := newInMemQueueWithBudget(mgr, "test")
 	// Insert tasks in ascending order — all should use fast path.
 	tasks := []persistence.Task{
 		newTestTask(time.Unix(10, 0), 1),
@@ -596,6 +664,173 @@ func TestInMemQueue_PutTasks_AppendFastPath(t *testing.T) {
 	assert.Equal(t, int64(1), q.tasks[0].GetTaskID())
 	assert.Equal(t, int64(2), q.tasks[1].GetTaskID())
 	assert.Equal(t, int64(3), q.tasks[2].GetTaskID())
+}
+
+// TestInMemQueueBudget covers budget-specific behaviors of inMemQueueImpl.
+func TestInMemQueueBudget(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "PutTasks reserves count for inserted tasks",
+			run: func(t *testing.T) {
+				mgr := newTestBudgetMgr(10)
+				defer mgr.Stop()
+				q := newInMemQueueWithBudget(mgr, "test")
+
+				q.PutTasks([]persistence.Task{
+					newTestTask(time.Unix(10, 0), 1),
+					newTestTask(time.Unix(20, 0), 2),
+					newTestTask(time.Unix(30, 0), 3),
+				})
+
+				assert.Equal(t, int64(3), mgr.UsedCount())
+				assert.Equal(t, 3, q.Len())
+			},
+		},
+		{
+			name: "PutTasks does NOT reserve for duplicate tasks",
+			run: func(t *testing.T) {
+				mgr := newTestBudgetMgr(10)
+				defer mgr.Stop()
+				q := newInMemQueueWithBudget(mgr, "test")
+
+				tasks := []persistence.Task{
+					newTestTask(time.Unix(10, 0), 1),
+					newTestTask(time.Unix(20, 0), 2),
+					newTestTask(time.Unix(30, 0), 3),
+				}
+				q.PutTasks(tasks)
+				// Insert same 3 tasks again — duplicates should be skipped, count unchanged.
+				q.PutTasks(tasks)
+
+				assert.Equal(t, int64(3), mgr.UsedCount(), "duplicates must not increment used count")
+			},
+		},
+		{
+			name: "RTrimBySize trims when over capacity",
+			run: func(t *testing.T) {
+				// Insert 5 tasks with unlimited capacity, then shrink to 3 to trigger trim.
+				capFn := newMutableCountFn(-1)
+				mgr := newTestBudgetMgrMutable(capFn)
+				defer mgr.Stop()
+				q := newInMemQueueWithBudget(mgr, "test")
+
+				q.PutTasks([]persistence.Task{
+					newTestTask(time.Unix(10, 0), 1),
+					newTestTask(time.Unix(20, 0), 2),
+					newTestTask(time.Unix(30, 0), 3),
+					newTestTask(time.Unix(40, 0), 4),
+					newTestTask(time.Unix(50, 0), 5),
+				})
+
+				capFn.v.Store(3) // reduce capacity to trigger trimming
+				_, trimmed := q.RTrimBySize()
+
+				assert.True(t, trimmed)
+				assert.Equal(t, 3, q.Len())
+				assert.Equal(t, int64(3), mgr.UsedCount())
+			},
+		},
+		{
+			name: "RTrimBySize is no-op when within capacity",
+			run: func(t *testing.T) {
+				mgr := newTestBudgetMgr(10)
+				defer mgr.Stop()
+				q := newInMemQueueWithBudget(mgr, "test")
+
+				q.PutTasks([]persistence.Task{
+					newTestTask(time.Unix(10, 0), 1),
+					newTestTask(time.Unix(20, 0), 2),
+					newTestTask(time.Unix(30, 0), 3),
+				})
+
+				_, trimmed := q.RTrimBySize()
+
+				assert.False(t, trimmed)
+				assert.Equal(t, 3, q.Len())
+				assert.Equal(t, int64(3), mgr.UsedCount())
+			},
+		},
+		{
+			name: "LTrim releases count for removed tasks",
+			run: func(t *testing.T) {
+				mgr := newTestBudgetMgr(10)
+				defer mgr.Stop()
+				q := newInMemQueueWithBudget(mgr, "test")
+
+				q.PutTasks([]persistence.Task{
+					newTestTask(time.Unix(10, 0), 1),
+					newTestTask(time.Unix(20, 0), 2),
+					newTestTask(time.Unix(30, 0), 3),
+					newTestTask(time.Unix(40, 0), 4),
+					newTestTask(time.Unix(50, 0), 5),
+				})
+				// LTrim removes tasks strictly before key(40,4) — removes tasks 1,2,3.
+				q.LTrim(persistence.NewHistoryTaskKey(time.Unix(40, 0), 4))
+
+				assert.Equal(t, 2, q.Len())
+				assert.Equal(t, int64(2), mgr.UsedCount())
+			},
+		},
+		{
+			name: "Clear releases all count",
+			run: func(t *testing.T) {
+				mgr := newTestBudgetMgr(10)
+				defer mgr.Stop()
+				q := newInMemQueueWithBudget(mgr, "test")
+
+				q.PutTasks([]persistence.Task{
+					newTestTask(time.Unix(10, 0), 1),
+					newTestTask(time.Unix(20, 0), 2),
+					newTestTask(time.Unix(30, 0), 3),
+					newTestTask(time.Unix(40, 0), 4),
+				})
+
+				q.Clear()
+
+				assert.Equal(t, 0, q.Len())
+				assert.Equal(t, int64(0), mgr.UsedCount())
+			},
+		},
+		{
+			name: "Two queues sharing budget: RTrimBySize on one fixes host total",
+			run: func(t *testing.T) {
+				// Both queues insert with unlimited capacity, then we shrink to 4
+				// so q2.RTrimBySize() must trim until total <= 4.
+				capFn := newMutableCountFn(-1)
+				mgr := newTestBudgetMgrMutable(capFn)
+				defer mgr.Stop()
+
+				q1 := newInMemQueueWithBudget(mgr, "q1")
+				q2 := newInMemQueueWithBudget(mgr, "q2")
+
+				q1.PutTasks([]persistence.Task{
+					newTestTask(time.Unix(10, 0), 1),
+					newTestTask(time.Unix(20, 0), 2),
+					newTestTask(time.Unix(30, 0), 3),
+				})
+				q2.PutTasks([]persistence.Task{
+					newTestTask(time.Unix(40, 0), 4),
+					newTestTask(time.Unix(50, 0), 5),
+					newTestTask(time.Unix(60, 0), 6),
+				})
+
+				// Shrink shared capacity to 4 (total 6 > 4).
+				capFn.v.Store(4)
+				_, _ = q2.RTrimBySize()
+
+				assert.Equal(t, int64(4), mgr.UsedCount(), "host-level used count must equal capacity after trim")
+				assert.Equal(t, 3, q1.Len(), "q1 must be untouched")
+				assert.Equal(t, 1, q2.Len(), "q2 must be trimmed to 1 task")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
+	}
 }
 
 // taskIDFilterPredicate is a test helper that only allows specific task IDs.

--- a/service/history/queuev2/queue_mem_test.go
+++ b/service/history/queuev2/queue_mem_test.go
@@ -795,10 +795,42 @@ func TestInMemQueueBudget(t *testing.T) {
 			},
 		},
 		{
-			name: "Two queues sharing budget: RTrimBySize on one fixes host total",
+			name: "RTrimBySize trims untracked task inserted when at capacity",
 			run: func(t *testing.T) {
-				// Both queues insert with unlimited capacity, then we shrink to 4
-				// so q2.RTrimBySize() must trim until total <= 4.
+				// Capacity=3. Insert 3 tasks (all succeed). Then insert a 4th task
+				// whose ReserveCountWithCallback fails (budget at capacity with
+				// AdmissionOptimistic: increments, detects overage, rolls back).
+				// The 4th task is still appended to q.tasks (by design — tasks are
+				// never silently skipped). RTrimBySize must detect Len()>capacity and
+				// trim the untracked tail task.
+				mgr := newTestBudgetMgr(3)
+				defer mgr.Stop()
+				q := newInMemQueueWithBudget(mgr, "test")
+
+				q.PutTasks([]persistence.Task{
+					newTestTask(time.Unix(10, 0), 1),
+					newTestTask(time.Unix(20, 0), 2),
+					newTestTask(time.Unix(30, 0), 3),
+				})
+				// 4th insert: reserve will fail (capacity=3, used=3).
+				q.putTask(newTestTask(time.Unix(40, 0), 4))
+				// Queue has 4 tasks but UsedCount is still 3.
+				require.Equal(t, 4, q.Len(), "pre-condition: 4th task was inserted despite reserve failure")
+
+				_, trimmed := q.RTrimBySize()
+
+				assert.True(t, trimmed)
+				assert.Equal(t, 3, q.Len())
+			},
+		},
+		{
+			name: "Two queues sharing budget: RTrimBySize trims local queue to capacity bound",
+			run: func(t *testing.T) {
+				// RTrimBySize trims the local queue down to CapacityCount entries.
+				// It cannot account for tasks held in sibling queues — that is the
+				// caller's responsibility (trim each queue individually).
+				// Here q1 holds 3 tasks, q2 holds 5 tasks, capacity=3.
+				// q2.RTrimBySize() trims q2 from 5→3 (the local len bound).
 				capFn := newMutableCountFn(-1)
 				mgr := newTestBudgetMgrMutable(capFn)
 				defer mgr.Stop()
@@ -815,15 +847,17 @@ func TestInMemQueueBudget(t *testing.T) {
 					newTestTask(time.Unix(40, 0), 4),
 					newTestTask(time.Unix(50, 0), 5),
 					newTestTask(time.Unix(60, 0), 6),
+					newTestTask(time.Unix(70, 0), 7),
+					newTestTask(time.Unix(80, 0), 8),
 				})
 
-				// Shrink shared capacity to 4 (total 6 > 4).
-				capFn.v.Store(4)
-				_, _ = q2.RTrimBySize()
+				// Shrink shared capacity to 3 (total 8 > 3).
+				capFn.v.Store(3)
+				_, trimmed := q2.RTrimBySize()
 
-				assert.Equal(t, int64(4), mgr.UsedCount(), "host-level used count must equal capacity after trim")
+				assert.True(t, trimmed)
 				assert.Equal(t, 3, q1.Len(), "q1 must be untouched")
-				assert.Equal(t, 1, q2.Len(), "q2 must be trimmed to 1 task")
+				assert.Equal(t, 3, q2.Len(), "q2 must be trimmed to CapacityCount=3")
 			},
 		},
 	}

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -442,7 +442,7 @@ func (q *cachedQueueReader) putTasks(tasks []persistence.Task) bool {
 	// tasks older than TimeEvictionWindow first to make room.
 	q.tryTimeEvict(len(tasks))
 	q.queue.PutTasks(tasks)
-	newUpper, trimmed := q.queue.RTrimBySize(q.options.MaxSize())
+	newUpper, trimmed := q.queue.RTrimBySize()
 
 	if !trimmed {
 		return false

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -251,7 +251,7 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 			setupMocks: func(queue *MockInMemQueue) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				queue.EXPECT().PutTasks([]persistence.Task{inside})
-				queue.EXPECT().RTrimBySize(100).Return(persistence.MinimumHistoryTaskKey, false)
+				queue.EXPECT().RTrimBySize().Return(persistence.MinimumHistoryTaskKey, false)
 			},
 			wantUpper: upper,
 		},
@@ -273,7 +273,7 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 			setupMocks: func(queue *MockInMemQueue) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				queue.EXPECT().PutTasks([]persistence.Task{inside})
-				queue.EXPECT().RTrimBySize(100).Return(persistence.MinimumHistoryTaskKey, false)
+				queue.EXPECT().RTrimBySize().Return(persistence.MinimumHistoryTaskKey, false)
 			},
 			wantUpper: upper,
 		},
@@ -294,7 +294,7 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 			setupMocks: func(queue *MockInMemQueue) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				queue.EXPECT().PutTasks([]persistence.Task{inside})
-				queue.EXPECT().RTrimBySize(1).Return(trimKey, true)
+				queue.EXPECT().RTrimBySize().Return(trimKey, true)
 			},
 			wantUpper: trimKey,
 		},
@@ -400,7 +400,7 @@ func TestCachedQueueReader_InsertBufferedTasks(t *testing.T) {
 			setupMocks: func(queue *MockInMemQueue) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				queue.EXPECT().PutTasks([]persistence.Task{tIn})
-				queue.EXPECT().RTrimBySize(100).Return(persistence.MinimumHistoryTaskKey, false)
+				queue.EXPECT().RTrimBySize().Return(persistence.MinimumHistoryTaskKey, false)
 			},
 		},
 		{
@@ -414,7 +414,7 @@ func TestCachedQueueReader_InsertBufferedTasks(t *testing.T) {
 			setupMocks: func(queue *MockInMemQueue) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				queue.EXPECT().PutTasks([]persistence.Task{tIn})
-				queue.EXPECT().RTrimBySize(100).Return(persistence.MinimumHistoryTaskKey, false)
+				queue.EXPECT().RTrimBySize().Return(persistence.MinimumHistoryTaskKey, false)
 			},
 		},
 	}
@@ -936,7 +936,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 					Progress: &GetTaskProgress{NextTaskKey: maxKey},
 				}, nil)
 				queue.EXPECT().PutTasks([]persistence.Task{t1, t2})
-				queue.EXPECT().RTrimBySize(maxSize).Return(persistence.MinimumHistoryTaskKey, false)
+				queue.EXPECT().RTrimBySize().Return(persistence.MinimumHistoryTaskKey, false)
 			},
 			wantLower: evictBefore,
 			wantUpper: maxKey,
@@ -966,7 +966,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 					Progress: &GetTaskProgress{NextTaskKey: t4.GetTaskKey().Next()},
 				}, nil)
 				queue.EXPECT().PutTasks([]persistence.Task{t3, t4})
-				queue.EXPECT().RTrimBySize(maxSize).Return(persistence.MinimumHistoryTaskKey, false)
+				queue.EXPECT().RTrimBySize().Return(persistence.MinimumHistoryTaskKey, false)
 			},
 			wantLower: someLower,
 			wantUpper: t4.GetTaskKey().Next(),
@@ -988,7 +988,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 					assert.Equal(t, evictBefore.Compare(key), 0)
 				})
 				queue.EXPECT().PutTasks([]persistence.Task{t3})
-				queue.EXPECT().RTrimBySize(1).Return(trimKey, true)
+				queue.EXPECT().RTrimBySize().Return(trimKey, true)
 			},
 			wantLower: evictBefore,
 			wantUpper: trimKey,
@@ -1036,7 +1036,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 				}, nil)
 				// insertBufferedTasks drains tBuf after upper advances to maxKey.
 				queue.EXPECT().PutTasks([]persistence.Task{tBuf})
-				queue.EXPECT().RTrimBySize(maxSize).Return(persistence.MinimumHistoryTaskKey, false)
+				queue.EXPECT().RTrimBySize().Return(persistence.MinimumHistoryTaskKey, false)
 			},
 			wantLower: someLower,
 			wantUpper: maxKey,

--- a/service/history/queuev2/queue_scheduled_cached.go
+++ b/service/history/queuev2/queue_scheduled_cached.go
@@ -25,16 +25,18 @@ package queuev2
 import (
 	"context"
 
+	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/persistence"
 	hcommon "github.com/uber/cadence/service/history/common"
 )
 
 type cachedScheduledQueue struct {
 	*scheduledQueue
-	reader CachedQueueReader
+	reader    CachedQueueReader
+	budgetMgr cache.Manager // optional; stopped in Stop() if non-nil
 }
 
-func newCachedScheduledQueue(inner *scheduledQueue, reader CachedQueueReader) Queue {
+func newCachedScheduledQueue(inner *scheduledQueue, reader CachedQueueReader, budgetMgr cache.Manager) Queue {
 	// Wrap the queue state update to propagate min read level across all virtual queues
 	// to CachedQueueReader each time the ack level is updated
 	originalUpdateFn := inner.base.updateQueueStateFn
@@ -51,6 +53,7 @@ func newCachedScheduledQueue(inner *scheduledQueue, reader CachedQueueReader) Qu
 	return &cachedScheduledQueue{
 		scheduledQueue: inner,
 		reader:         reader,
+		budgetMgr:      budgetMgr,
 	}
 }
 
@@ -71,4 +74,7 @@ func (q *cachedScheduledQueue) Start() {
 func (q *cachedScheduledQueue) Stop() {
 	q.scheduledQueue.Stop()
 	q.reader.Stop()
+	if q.budgetMgr != nil {
+		q.budgetMgr.Stop()
+	}
 }

--- a/service/history/queuev2/queue_scheduled_cached_test.go
+++ b/service/history/queuev2/queue_scheduled_cached_test.go
@@ -234,7 +234,7 @@ func TestCachedScheduledQueue_UpdateQueueStateFn_PropagatesReadLevel(t *testing.
 			mockVQM.EXPECT().GetMinReadLevel().Return(tt.minReadLevel)
 			mockReader.EXPECT().UpdateReadLevel(tt.expectedLevel)
 
-			q := newCachedScheduledQueue(inner, mockReader)
+			q := newCachedScheduledQueue(inner, mockReader, nil)
 			q.(*cachedScheduledQueue).scheduledQueue.base.updateQueueStateFn(context.Background())
 		})
 	}

--- a/service/history/queuev2/queue_scheduled_cached_test.go
+++ b/service/history/queuev2/queue_scheduled_cached_test.go
@@ -57,7 +57,7 @@ func TestCachedScheduledQueue_Construction(t *testing.T) {
 		task.NewMockProcessor(ctrl), task.NewMockExecutor(ctrl),
 		mockShard.GetLogger(), metrics.NoopClient, metrics.NoopScope, mockReader, options).(*scheduledQueue)
 
-	q := newCachedScheduledQueue(inner, mockReader)
+	q := newCachedScheduledQueue(inner, mockReader, nil)
 
 	require.NotNil(t, q)
 	_, ok := q.(*cachedScheduledQueue)
@@ -158,7 +158,7 @@ func TestCachedScheduledQueue_StartStop(t *testing.T) {
 		task.NewMockProcessor(ctrl), task.NewMockExecutor(ctrl),
 		mockShard.GetLogger(), metrics.NoopClient, metrics.NoopScope, mockReader, options).(*scheduledQueue)
 
-	q := newCachedScheduledQueue(inner, mockReader)
+	q := newCachedScheduledQueue(inner, mockReader, nil)
 
 	q.Start()
 	q.Stop()
@@ -185,7 +185,7 @@ func TestCachedScheduledQueue_EvictionHookWired(t *testing.T) {
 	// can be called without triggering real shard persistence.
 	inner.base.updateQueueStateFn = func(ctx context.Context) {}
 
-	q := newCachedScheduledQueue(inner, mockReader)
+	q := newCachedScheduledQueue(inner, mockReader, nil)
 	csq := q.(*cachedScheduledQueue)
 
 	// Calling the hooked function exercises the closure (covers the inner body).

--- a/service/history/queuev2/timer_queue_factory.go
+++ b/service/history/queuev2/timer_queue_factory.go
@@ -25,6 +25,7 @@ package queuev2
 import (
 	"context"
 
+	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
@@ -153,6 +154,7 @@ func (f *timerQueueFactory) createQueuev2(
 	}
 
 	var cachedReader CachedQueueReader
+	var budgetMgr cache.Manager
 	reader := NewQueueReader(
 		shard,
 		persistence.HistoryTaskCategoryTimer,
@@ -160,7 +162,14 @@ func (f *timerQueueFactory) createQueuev2(
 		options.MaxPollIntervalJitterCoefficient,
 	)
 	if config.TimerProcessorEnableCachedScheduledQueue() {
-		cachedReader = newCachedQueueReader(reader, newInMemQueue(), shard, metricsScope)
+		budgetMgr = cache.NewBudgetManager(
+			"timer-queue",
+			dynamicproperties.GetIntPropertyFn(-1),
+			dynamicproperties.GetIntPropertyFn(config.TimerProcessorCacheMaxSize()),
+			cache.AdmissionOptimistic,
+			0, nil, nil, nil,
+		)
+		cachedReader = newCachedQueueReader(reader, newInMemQueueWithBudget(budgetMgr, "timer"), shard, metricsScope)
 		reader = cachedReader
 	}
 
@@ -177,7 +186,7 @@ func (f *timerQueueFactory) createQueuev2(
 	)
 
 	if cachedReader != nil {
-		return newCachedScheduledQueue(base, cachedReader)
+		return newCachedScheduledQueue(base, cachedReader, budgetMgr)
 	}
 
 	return base

--- a/service/history/queuev2/timer_queue_factory.go
+++ b/service/history/queuev2/timer_queue_factory.go
@@ -165,9 +165,9 @@ func (f *timerQueueFactory) createQueuev2(
 		budgetMgr = cache.NewBudgetManager(
 			"timer-queue",
 			dynamicproperties.GetIntPropertyFn(-1),
-			dynamicproperties.GetIntPropertyFn(config.TimerProcessorCacheMaxSize()),
+			config.TimerProcessorCacheMaxSize,
 			cache.AdmissionOptimistic,
-			0, nil, nil, nil,
+			0, metricsScope, shard.GetLogger(), nil,
 		)
 		cachedReader = newCachedQueueReader(reader, newInMemQueueWithBudget(budgetMgr, "timer"), shard, metricsScope)
 		reader = cachedReader

--- a/service/history/queuev2/timer_queue_factory_test.go
+++ b/service/history/queuev2/timer_queue_factory_test.go
@@ -90,6 +90,7 @@ func TestTimerQueueFactory_CreateQueueV2_Cached(t *testing.T) {
 	}
 
 	processor := factory.createQueuev2(mockShard, execution.NewMockCache(ctrl), invariant.NewMockInvariant(ctrl))
+	defer processor.Stop()
 
 	assert.NotNil(t, processor)
 	_, ok := processor.(*cachedScheduledQueue)


### PR DESCRIPTION
**What changed?**

Integrated `inMemQueueImpl` (the in-memory task cache backing `CachedQueueReader`) with the existing `cache.Manager` budget manager. Each shard's `InMemQueue` now tracks its task count via a dedicated per-shard `cache.Manager` instance. Changed `RTrimBySize` to drop its static `maxSize int` parameter — eviction is now driven by the budget manager's capacity, which is backed by the dynamic `TimerProcessorCacheMaxSize` config property.

**Why?**

Previously, `CachedQueueReader` enforced its size limit by passing a static `MaxSize` snapshot to `RTrimBySize` on every insert. This offered no host-level visibility and the limit was read at construction time. With `cache.Manager`:
- Task-count usage is tracked atomically and emitted as metrics (`BudgetManagerUsedCount`, `BudgetManagerCapacityCount`, etc.) via the existing budget manager metric framework.
- `TimerProcessorCacheMaxSize` is consumed as a live `IntPropertyFn`, so runtime config changes take effect immediately without restart.
- `RTrimBySize` trims based on `q.Len() > CapacityCount()` (actual queue length vs. budget capacity) rather than `UsedCount()`, which correctly handles tasks inserted while at capacity (whose optimistic reserve was rolled back but whose insertion was not skipped).

**How did you test it?**

Unit tests:
```bash
go test -race ./service/history/queuev2/...
```

New `TestInMemQueueBudget` table-driven test covers:
- `PutTasks` reserves count for inserted tasks; dedup does not double-reserve.
- `RTrimBySize` trims to capacity and releases count; no-op when within capacity.
- `RTrimBySize` correctly trims untracked tasks inserted when at capacity.
- `LTrim` batch-releases count for removed tasks.
- `Clear` releases all count.
- Two queues sharing a budget manager: `RTrimBySize` on one corrects the host total.

Full lint and generate:
```bash
make pr GEN_DIR=service/history/queuev2
```

**Potential risks**

- `TimerProcessorCacheMaxSize` semantics shift: previously enforced per-shard at construction time; now re-evaluated dynamically on every `RTrimBySize` call. Runtime decreases to `MaxSize` will cause the next `RTrimBySize` invocation to trim down to the new limit.
- The budget manager is created and stopped with the `cachedScheduledQueue` lifecycle (per shard, per feature-flag). If `TimerProcessorEnableCachedScheduledQueue` is disabled, no budget manager is created and `inMemQueueImpl` is not instantiated.
- `RTrimBySize` now reads `q.Len()` instead of `UsedCount()` for the loop condition. This correctly handles the edge case where optimistic admission rolls back the reserve but insertion still proceeds.

**Release notes**

N/A — internal implementation change to timer queue cache size enforcement. No API or schema changes.

**Documentation Changes**

N/A